### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/neurosting.yml
+++ b/.github/workflows/neurosting.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Neurosting/Neurosting/security/code-scanning/1](https://github.com/Neurosting/Neurosting/security/code-scanning/1)

To fix the problem, explicitly limit the `GITHUB_TOKEN` permissions in the workflow to the least privilege needed. In this workflow, the job only checks out code and runs local commands; that requires at most read access to repository contents. Therefore, we should add a `permissions:` block with `contents: read`. This can be done at the workflow root (applies to all jobs) or within the `test` job. Adding it at the root is simpler and future‑proof for additional jobs.

Concretely, in `.github/workflows/neurosting.yml`, add a new `permissions:` section near the top, aligned with `on:` and `jobs:` (same indentation level). For example, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No additional imports, methods, or other definitions are needed since this is just a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
